### PR TITLE
Fix start period to be seconds to fix docker error

### DIFF
--- a/cmd/skupper-docker-cli/main.go
+++ b/cmd/skupper-docker-cli/main.go
@@ -531,7 +531,7 @@ func routerContainerConfig(router *Router) *dockercontainer.Config {
 		Env:      routerEnv(router),
 		Healthcheck: &dockercontainer.HealthConfig{
 			Test:        []string{"curl --fail -s http://localhost:9090/healthz || exit 1"},
-			StartPeriod: time.Duration(60),
+			StartPeriod: (time.Duration(60)*time.Second),
 		},
 		Labels:       labels,
 		ExposedPorts: routerPorts(router),
@@ -608,7 +608,7 @@ func restartRouterContainer(dd libdocker.Interface) {
 			Image:    current.Config.Image,
 			Healthcheck: &dockercontainer.HealthConfig{
 				Test:        []string{"curl --fail -s http://localhost:9090/healthz || exit 1"},
-				StartPeriod: time.Duration(60),
+				StartPeriod: (time.Duration(60)*time.Second),
 			},
 			Labels:       current.Config.Labels,
 			ExposedPorts: current.Config.ExposedPorts,


### PR DESCRIPTION
Error when starting:

```
./skupper-docker init --edge --enable-proxy-controller --enable-router-console --enable-service-sync --router-console-auth unsecured

2020/03/31 21:58:22 Failed to create skupper router container: Error response from daemon: StartPeriod in Healthcheck cannot be less than 1ms
```